### PR TITLE
增加了从命令行获取ConfigClientOptions参数

### DIFF
--- a/AgileConfig.Client/AgileConfig.Client.csproj
+++ b/AgileConfig.Client/AgileConfig.Client.csproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.0" />

--- a/AgileConfig.Client/ConfigClientOptions.cs
+++ b/AgileConfig.Client/ConfigClientOptions.cs
@@ -70,7 +70,10 @@ namespace AgileConfig.Client
 
             var localconfig = new ConfigurationBuilder()
                              .SetBasePath(rootDir)
-                             .AddJsonFile(json).AddEnvironmentVariables().Build();
+                             .AddJsonFile(json)
+                             .AddEnvironmentVariables()
+                             .AddCommandLine(Environment.GetCommandLineArgs())
+                             .Build();
 
             var configSection = localconfig.GetSection("AgileConfig");
             if (!configSection.Exists())
@@ -90,7 +93,10 @@ namespace AgileConfig.Client
 
             var localconfig = new ConfigurationBuilder()
                              .SetBasePath(rootDir)
-                             .AddJsonFile(json).AddEnvironmentVariables().Build();
+                             .AddJsonFile(json)
+                             .AddEnvironmentVariables()
+                             .AddCommandLine(Environment.GetCommandLineArgs())
+                             .Build();
 
             return FromConfiguration(localconfig);
         }


### PR DESCRIPTION
至此, ConfigClientOptions的参数来源有,appsettings.{env}.json \ 环境变量 \ 命令行