### PR TITLE
修复注册服务时首次自动生成ServiceId缓存文件时文件夹不存在的bug

### DIFF
--- a/AgileConfig.Client/ConfigClientOptions.cs
+++ b/AgileConfig.Client/ConfigClientOptions.cs
@@ -234,6 +234,11 @@ namespace AgileConfig.Client
 
         private static void WriteIdToLocal(string cacheDir, string appId, string serviceId)
         {
+            if (!string.IsNullOrWhiteSpace(cacheDir) && !Directory.Exists(cacheDir))
+            {
+                Directory.CreateDirectory(cacheDir);
+            }
+
             string idFileName = Path.Combine(cacheDir, $"{appId}.agileconfig.client.serviceid");
 
             File.WriteAllText(idFileName, serviceId);


### PR DESCRIPTION
#31 [修复注册服务时首次自动生成ServiceId缓存文件时文件夹不存在的bug]