### PR TITLE
OrderBy导致的客户端频繁reload

### DIFF
--- a/AgileConfig.Client/ConfigClient.cs
+++ b/AgileConfig.Client/ConfigClient.cs
@@ -1,4 +1,5 @@
 ﻿using AgileConfig.Client.MessageHandlers;
+using AgileConfig.Client.Utils;
 using AgileConfig.Protocol;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -367,7 +368,7 @@ namespace AgileConfig.Client
             client.Options.SetRequestHeader("appid", AppId);
             client.Options.SetRequestHeader("env", Env);
             client.Options.SetRequestHeader("Authorization", GenerateBasicAuthorization(AppId, Secret));
-            client.Options.SetRequestHeader("client-v", AssemablyUtil.GetVer());
+            client.Options.SetRequestHeader("client-v", AssemblyUtil.GetVer());
 
             var randomServer = new RandomServers(ServerNodes);
             int failCount = 0;
@@ -827,8 +828,8 @@ namespace AgileConfig.Client
 
         public string DataMd5Version()
         {
-            var keyStr = string.Join("&", Data.Keys.ToArray().OrderBy(k => k));
-            var valueStr = string.Join("&", Data.Values.ToArray().OrderBy(v => v));
+            var keyStr = string.Join("&", Data.Keys.ToArray().OrderBy(k => k, StringComparer.InvariantCultureIgnoreCase));
+            var valueStr = string.Join("&", Data.Values.ToArray().OrderBy(v => v, StringComparer.InvariantCultureIgnoreCase));
             var txt = $"{keyStr}&{valueStr}";
 
             var md5 = Encrypt.Md5(txt);

--- a/AgileConfig.Client/RegisterCenter/DiscoveryService.cs
+++ b/AgileConfig.Client/RegisterCenter/DiscoveryService.cs
@@ -1,4 +1,5 @@
 ﻿using AgileConfig.Client.MessageHandlers;
+using AgileConfig.Client.Utils;
 using AgileConfig.Protocol;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;

--- a/AgileConfig.Client/RegisterCenter/Heartbeats/HttpChannel.cs
+++ b/AgileConfig.Client/RegisterCenter/Heartbeats/HttpChannel.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using AgileConfig.Client.Utils;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;

--- a/AgileConfig.Client/RegisterCenter/RegisterService.cs
+++ b/AgileConfig.Client/RegisterCenter/RegisterService.cs
@@ -1,4 +1,5 @@
 ﻿using AgileConfig.Client.RegisterCenter.Heartbeats;
+using AgileConfig.Client.Utils;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using System.Text;

--- a/AgileConfig.Client/Utils/AssemblyUtil.cs
+++ b/AgileConfig.Client/Utils/AssemblyUtil.cs
@@ -1,14 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace AgileConfig.Client
+﻿namespace AgileConfig.Client.Utils
 {
-    internal class AssemablyUtil
+    internal class AssemblyUtil
     {
         public static string GetVer()
         {
-            var type = typeof(AssemablyUtil);
+            var type = typeof(AssemblyUtil);
             var ver = type.Assembly.GetName().Version;
 
             return $"{ver.Major}.{ver.Minor}.{ver.Build}";

--- a/AgileConfig.Client/Utils/HttpUtil.cs
+++ b/AgileConfig.Client/Utils/HttpUtil.cs
@@ -1,11 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace AgileConfig.Client
+namespace AgileConfig.Client.Utils
 {
     class HttpUtil
     {
@@ -48,7 +47,7 @@ namespace AgileConfig.Client
                 }
             }
 
-            var response = (await request.GetResponseAsync()) as HttpWebResponse;
+            var response = await request.GetResponseAsync() as HttpWebResponse;
 
             return response;
         }
@@ -82,7 +81,7 @@ namespace AgileConfig.Client
                 }
             }
 
-            var response = (await request.GetResponseAsync()) as HttpWebResponse;
+            var response = await request.GetResponseAsync() as HttpWebResponse;
 
             return response;
         }
@@ -117,7 +116,7 @@ namespace AgileConfig.Client
                 }
             }
 
-            var response = (await request.GetResponseAsync()) as HttpWebResponse;
+            var response = await request.GetResponseAsync() as HttpWebResponse;
 
             return response;
         }


### PR DESCRIPTION
Description:
- 重命名AssemablyUtil类名称为AssemblyUtil
- 添加Utils文件夹，统一收纳Util类
- 客户端计算配置的MD5时，OrderBy更改为忽略区域文化、大小写的实现，避免服务端和客户端区域文化不一致导致的频繁reload问题。

Issue(s) addressed:
- None

Changes:
- AssemablyUtil
- ConfigClient.DataMd5Version

Reviewers:
@kklldog 