### PR TITLE
IConfiguration中的数据更新慢于ConfigClient.ReLoaded事件

### DIFF
--- a/AgileConfig.Client/Extensions/ConfigurationBuilderExtension.cs
+++ b/AgileConfig.Client/Extensions/ConfigurationBuilderExtension.cs
@@ -1,7 +1,6 @@
 ﻿using AgileConfig.Client;
 using Microsoft.Extensions.Configuration;
 using System;
-using System.Collections.Generic;
 
 namespace Microsoft.AspNetCore.Hosting
 {
@@ -11,12 +10,12 @@ namespace Microsoft.AspNetCore.Hosting
            this IConfigurationBuilder builder,
            IConfigClient client, Action<ConfigReloadedArgs> evt = null)
         {
-            if (evt != null)
-            {
-                client.ReLoaded += evt;
-            }
+            var configurationBuilder = builder.Add(new AgileConfigSource(client));
 
-            return builder.Add(new AgileConfigSource(client));
+            if (evt != null)
+                client.ReLoaded += evt;
+
+            return configurationBuilder;
         }
 
         public static IConfigurationBuilder AddAgileConfig(
@@ -30,12 +29,12 @@ namespace Microsoft.AspNetCore.Hosting
             this IConfigurationBuilder builder,
             IConfigClient client, Action<ConfigChangedArg> e)
         {
-            if (e != null)
-            {
-                client.ConfigChanged += e;
-            }
+            var configurationBuilder = builder.Add(new AgileConfigSource(client));
 
-            return builder.Add(new AgileConfigSource(client));
+            if (e != null)
+                client.ConfigChanged += e;
+
+            return configurationBuilder;
         }
 
         [Obsolete("ConfigChanged event will be obsolete.")]


### PR DESCRIPTION
Description:
- 先注册IConfigurationSource，后注册用户绑定的ReLoaded事件，保证配置变更后先触发IConfigurationSource后触发用户绑定的ReLoaded事件

Issue(s) addressed:
- #41 

Changes:
- ConfigurationBuilderExtension

Reviewers:
@kklldog 