### PR TITLE
Translate repository documentation and comments to English

### DIFF
--- a/AgileConfig.Client/AgileConfigProvider.cs
+++ b/AgileConfig.Client/AgileConfigProvider.cs
@@ -19,7 +19,7 @@ namespace AgileConfig.Client
         }
 
         /// <summary>
-        /// load方法调用ConfigClient的Connect方法,Connect方法会在连接成功后拉取所有的配置。
+        /// `Load` calls `ConfigClient.ConnectAsync`, which fetches all configuration after establishing the connection.
         /// </summary>
         public override void Load()
         {

--- a/AgileConfig.Client/ConfigClient.cs
+++ b/AgileConfig.Client/ConfigClient.cs
@@ -37,8 +37,10 @@ namespace AgileConfig.Client
         private string LocalCacheFileName => Path.Combine(_options.CacheDirectory, $"{_options.AppId}.agileconfig.client.configs.cache");
 
         /// <summary>
-        /// client的实例对象，每次new的时候构造函数会吧this直接赋值给Instance，
-        /// 一般来说你可以直接使用这个属性来拿到client对象，但是如果你手动new多个client的话，这个Instance代表最后new的那一个client，强烈不建议这么玩。
+        /// Singleton-like access to the most recently created client instance.
+        /// Each constructor assigns `this` to `Instance`. Creating multiple clients
+        /// will therefore cause `Instance` to reference the last one, so avoid
+        /// instantiating more than one client manually.
         /// </summary>
         public static IConfigClient Instance { get; private set; }
 
@@ -55,7 +57,7 @@ namespace AgileConfig.Client
             {
                 if (_options.Logger == null)
                 {
-                    // 给一个默认的 console logger
+                    // Provide a default console logger if none is supplied.
                     return ConfigClientOptions.DefaultConsoleLogger;
                 }
 
@@ -85,7 +87,7 @@ namespace AgileConfig.Client
         }
 
         /// <summary>
-        /// http 超时时间 , 单位秒 , 默认100
+        /// HTTP timeout in seconds (default 100).
         /// </summary>
         public int HttpTimeout
         {
@@ -94,12 +96,12 @@ namespace AgileConfig.Client
         }
 
         /// <summary>
-        /// 是否读取的事本地缓存的配置
+        /// Indicates whether the configuration was loaded from the local cache.
         /// </summary>
         public bool IsLoadFromLocal => _isLoadFromLocal;
 
         /// <summary>
-        /// 最新的配置(全量)被加载到本地后触发。
+        /// Raised after the latest full configuration has been loaded locally.
         /// </summary>
         public event Action<ConfigReloadedArgs> ReLoaded
         {
@@ -108,7 +110,7 @@ namespace AgileConfig.Client
         }
 
         /// <summary>
-        /// 配置项修改事件
+        /// Event raised when configuration items change.
         /// </summary>
         [Obsolete("ConfigChanged event will be obsolete, use ReLoaded event instead of.")]
         public event Action<ConfigChangedArg> ConfigChanged
@@ -118,7 +120,7 @@ namespace AgileConfig.Client
         }
 
         /// <summary>
-        /// 所有的配置项最后都会转换为字典
+        /// All configuration entries are ultimately stored in this dictionary.
         /// </summary>
         public ConcurrentDictionary<string, string> Data => _data;
 
@@ -139,7 +141,7 @@ namespace AgileConfig.Client
         }
 
         /// <summary>
-        /// 根据键值获取配置值
+        /// Get a configuration value by key.
         /// </summary>
         /// <param name="key"></param>
         /// <returns></returns>
@@ -168,7 +170,7 @@ namespace AgileConfig.Client
         }
 
         /// <summary>
-        /// 保证cache文件夹存在
+        /// Ensure the cache directory exists.
         /// </summary>
         private void EnsureCacheDir()
         {
@@ -186,7 +188,7 @@ namespace AgileConfig.Client
             }
 
             this.SetOptions(options);
-            //兼容老版本的 ConfigChanged 事件
+            // Backward compatibility for the legacy ConfigChanged event.
             this._options.ReLoaded += (_) =>
             {
                 this._options.ConfigChanged?.Invoke(new ConfigChangedArg(ActionConst.Reload, ""));
@@ -201,7 +203,7 @@ namespace AgileConfig.Client
 
             var options = ConfigClientOptions.FromLocalAppsettings(json);
             this.SetOptions(options);
-            //兼容老版本的 ConfigChanged 事件
+            // Backward compatibility for the legacy ConfigChanged event.
             this._options.ReLoaded += (_) =>
             {
                 this._options.ConfigChanged?.Invoke(new ConfigChangedArg(ActionConst.Reload, ""));
@@ -226,7 +228,7 @@ namespace AgileConfig.Client
             var options = ConfigClientOptions.FromConfiguration(configuration);
             options.Logger = logger;
             this.SetOptions(options);
-            //兼容老版本的 ConfigChanged 事件
+            // Backward compatibility for the legacy ConfigChanged event.
             this._options.ReLoaded += (_) =>
             {
                 this._options.ConfigChanged?.Invoke(new ConfigChangedArg(ActionConst.Reload, ""));
@@ -252,7 +254,7 @@ namespace AgileConfig.Client
             options.ENV = env;
             options.Logger = logger;
             this.SetOptions(options);
-            //兼容老版本的 ConfigChanged 事件
+            // Backward compatibility for the legacy ConfigChanged event.
             this._options.ReLoaded += (_) =>
             {
                 this._options.ConfigChanged?.Invoke(new ConfigChangedArg(ActionConst.Reload, ""));
@@ -261,7 +263,7 @@ namespace AgileConfig.Client
         }
 
         /// <summary>
-        /// 获取分组配置信息
+        /// Retrieve configuration items by group name.
         /// </summary>
         /// <param name="groupName"></param>
         /// <returns></returns>
@@ -276,7 +278,7 @@ namespace AgileConfig.Client
         }
 
         /// <summary>
-        /// 连接服务端
+        /// Connect to the configuration server.
         /// </summary>
         /// <returns></returns>
         public async Task<bool> ConnectAsync()
@@ -302,13 +304,13 @@ namespace AgileConfig.Client
             }
 
             var connected = await TryConnectWebsocketAsync(_websocketClient).ConfigureAwait(false);
-            await Load();//不管websocket是否成功，都去拉一次配置
+            await Load();//Always pull configuration even if WebSocket setup fails.
             if (connected)
             {
                 HandleWebsocketMessageAsync();
                 WebsocketHeartbeatAsync();
             }
-            //设置自动重连
+            // Enable automatic reconnection.
             AutoReConnect();
 
             return connected;
@@ -350,7 +352,7 @@ namespace AgileConfig.Client
 
             if (failCount == randomServer.ServerCount)
             {
-                //连接所有的服务器都失败了。
+                // Failed to connect to every server.
                 this.Status = ConnectStatus.Disconnected;
                 return false;
             }
@@ -360,7 +362,7 @@ namespace AgileConfig.Client
         }
 
         /// <summary>
-        /// 构造websocket连接的url
+        /// Build the WebSocket connection URL.
         /// </summary>
         /// <param name="server"></param>
         /// <param name="clientName"></param>
@@ -398,7 +400,8 @@ namespace AgileConfig.Client
         }
 
         /// <summary>
-        /// 开启一个线程来初始化Websocket Client，并且5s一次进行检查是否连接打开状态，如果不是则尝试重连。
+        /// Start a background task that initializes the WebSocket client and
+        /// checks the connection every five seconds, reconnecting if needed.
         /// </summary>
         /// <returns></returns>
         private void AutoReConnect()
@@ -454,7 +457,7 @@ namespace AgileConfig.Client
             return "Basic " + Convert.ToBase64String(data);
         }
         /// <summary>
-        /// 开启一个线程30s进行一次心跳
+        /// Start a background task that sends a heartbeat every 30 seconds.
         /// </summary>
         /// <returns></returns>
         public void WebsocketHeartbeatAsync()
@@ -475,7 +478,7 @@ namespace AgileConfig.Client
                     {
                         try
                         {
-                            //这里由于多线程的问题，WebsocketClient有可能在上一个if判断成功后被置空或者断开，所以需要try一下避免线程退出
+                            // Guard against race conditions where the client becomes null or closes between checks.
                             await _websocketClient.SendAsync(new ArraySegment<byte>(data, 0, data.Length), WebSocketMessageType.Text, true,
                                     CancellationToken.None).ConfigureAwait(false);
                             Logger?.LogTrace("client send 'ping' to server by websocket .");
@@ -489,7 +492,7 @@ namespace AgileConfig.Client
             }, TaskCreationOptions.LongRunning).ConfigureAwait(false);
         }
         /// <summary>
-        /// 开启一个线程对服务端推送的websocket message进行处理
+        /// Start a background task that processes WebSocket messages from the server.
         /// </summary>
         /// <returns></returns>
         private void HandleWebsocketMessageAsync()
@@ -555,7 +558,7 @@ namespace AgileConfig.Client
         }
 
         /// <summary>
-        /// 分发到消息到处理类
+        /// Dispatch messages to the appropriate handler.
         /// </summary>
         private async void ProcessMessage(WebSocketReceiveResult result, ArraySegment<Byte> buffer)
         {
@@ -613,7 +616,7 @@ namespace AgileConfig.Client
         }
 
         /// <summary>
-        /// 复制一个当前的配置字典
+        /// Clone the current configuration dictionary.
         /// </summary>
         /// <returns></returns>
         private Dictionary<string, string> CopyConfigDict()
@@ -631,7 +634,7 @@ namespace AgileConfig.Client
         }
 
         /// <summary>
-        /// 通过http从server拉取所有配置到本地
+        /// Pull all configuration items from the server via HTTP.
         /// </summary>
         public async Task<bool> Load()
         {

--- a/AgileConfig.Client/ConfigClientOptions.cs
+++ b/AgileConfig.Client/ConfigClientOptions.cs
@@ -30,7 +30,7 @@ namespace AgileConfig.Client
 
         public string CacheDirectory { get; set; }
         /// <summary>
-        /// 缓存加密
+        /// Encrypt cached configuration files.
         /// </summary>
         /// <value></value>
         public bool ConfigCacheEncrypt { get; set; } = false;
@@ -43,13 +43,13 @@ namespace AgileConfig.Client
         public Action<ConfigChangedArg> ConfigChanged;
 
         /// <summary>
-        /// 最新的配置被加载到本地后触发。
+        /// Raised after the newest configuration has been loaded locally.
         /// </summary>
         public Action<ConfigReloadedArgs> ReLoaded;
 
         /// <summary>
-        /// 确定当前目录是否存在 json 配置文件，使用多种获取目录的形式来确认。
-        /// 如果存在则返回当前目录的确切路径。
+        /// Ensure the current directory contains the json configuration file and
+        /// return the exact directory path when it does.
         /// </summary>
         /// <param name="json"></param>
         /// <returns></returns>
@@ -172,15 +172,15 @@ namespace AgileConfig.Client
             var serviceId = config["AgileConfig:serviceRegister:serviceId"];
             if (string.IsNullOrWhiteSpace(serviceId))
             {
-                // 如果配置文件上没有填尝试从本地恢复id
+                // Try recovering the ID from the local cache if it is missing in configuration.
                 serviceId = TryGetIdFromLocal(cacheDir, appId);
                 DefaultConsoleLogger.LogInformation("because serviceId is empty in the configuration , try to read serviceId from local cache file , the id = " + serviceId);
             }
             if (string.IsNullOrWhiteSpace(serviceId))
             {
-                // 如果从本地恢复 id 失败，则生产一个 guid
+                // Generate a GUID when restoration fails.
                 serviceId = Guid.NewGuid().ToString("N");
-                // 保存到本地以便恢复，防止服务重启后又生产一个 guid
+                // Persist it locally so the same ID is reused after restarts.
                 WriteIdToLocal(cacheDir, appId, serviceId);
                 DefaultConsoleLogger.LogInformation("generate a serviceId = " + serviceId);
             }

--- a/AgileConfig.Client/Encrypt.cs
+++ b/AgileConfig.Client/Encrypt.cs
@@ -25,7 +25,7 @@ namespace AgileConfig.Client
             }
         }
         /// <summary>
-        /// Aes ECB PKCS7Padding(PKCS5Padding) 加密 （与Java程序对接可使用）
+        /// AES ECB with PKCS7Padding (PKCS5Padding) encryption, compatible with Java clients.
         /// </summary>
         /// <param name="key"></param>
         /// <param name="rawData"></param>
@@ -51,7 +51,7 @@ namespace AgileConfig.Client
             return Convert.ToBase64String(resultArray);
         }
         /// <summary>
-        /// Aes ECB PKCS7Padding(PKCS5Padding) 解密 （与Java程序对接可使用）
+        /// AES ECB with PKCS7Padding (PKCS5Padding) decryption, compatible with Java clients.
         /// </summary>
         /// <param name="key"></param>
         /// <param name="base64Data"></param>

--- a/AgileConfig.Client/Extensions/ConfigurationBuilderExtension.cs
+++ b/AgileConfig.Client/Extensions/ConfigurationBuilderExtension.cs
@@ -63,7 +63,7 @@ namespace Microsoft.AspNetCore.Hosting
         }
 
         /// <summary>
-        /// 先尝试从本地的配置文件读取参数，然后合并 setOp Action的赋值
+        /// Load parameters from the local configuration file first, then merge values set by the action.
         /// </summary>
         /// <param name="builder"></param>
         /// <param name="setOp"></param>

--- a/AgileConfig.Client/MessageHandlers/ConfigCenterActionMessageHandler.cs
+++ b/AgileConfig.Client/MessageHandlers/ConfigCenterActionMessageHandler.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 namespace AgileConfig.Client.MessageHandlers
 {
     /// <summary>
-    /// 服务端回复配置client的action消息的处理类
+    /// Handler for action messages sent by the configuration server.
     /// </summary>
     class ConfigCenterActionMessageHandler
     {

--- a/AgileConfig.Client/MessageHandlers/DropMessageHandler.cs
+++ b/AgileConfig.Client/MessageHandlers/DropMessageHandler.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 namespace AgileConfig.Client.MessageHandlers
 {
     /// <summary>
-    /// 老版本的服务端回复配置client的心跳消息的处理类
+    /// Handler for legacy heartbeat messages returned by the configuration server.
     /// </summary>
     class DropMessageHandler
     {

--- a/AgileConfig.Client/MessageHandlers/OldConfigActionMessageHandler.cs
+++ b/AgileConfig.Client/MessageHandlers/OldConfigActionMessageHandler.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 namespace AgileConfig.Client.MessageHandlers
 {
     /// <summary>
-    /// 老版本的服务端回复配置client的action消息的处理类
+    /// Handler for legacy action messages returned by the configuration server.
     /// </summary>
     class OldConfigActionMessageHandler
     {

--- a/AgileConfig.Client/MessageHandlers/OldConfigPingRetrunMessageHandler.cs
+++ b/AgileConfig.Client/MessageHandlers/OldConfigPingRetrunMessageHandler.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 namespace AgileConfig.Client.MessageHandlers
 {
     /// <summary>
-    /// 老版本的服务端回复配置client的心跳消息的处理类
+    /// Handler for legacy heartbeat responses from the configuration server.
     /// </summary>
     class OldConfigPingRetrunMessageHandler
     {
@@ -26,7 +26,7 @@ namespace AgileConfig.Client.MessageHandlers
             var localVersion = client.DataMd5Version();
             if (version != localVersion)
             {
-                //如果数据库版本跟本地版本不一致则直接全部更新
+                // Reload everything when the server version differs from the local copy.
                 await client.Load();
             }
         }

--- a/AgileConfig.Client/RegisterCenter/DiscoveryService.cs
+++ b/AgileConfig.Client/RegisterCenter/DiscoveryService.cs
@@ -69,7 +69,7 @@ namespace AgileConfig.Client.RegisterCenter
                             if (!ver.Equals(DataVersion, StringComparison.CurrentCultureIgnoreCase))
                             {
                                 _logger.LogInformation($"server return service infos version {ver} is different from local version {DataVersion} so refresh .");
-                                //如果服务端跟客户端的版本不一样直接刷新
+                                // Refresh immediately if the server version differs from the local one.
                                 _ = RefreshAsync();
                             }
                             return;
@@ -84,7 +84,7 @@ namespace AgileConfig.Client.RegisterCenter
         }
 
         /// <summary>
-        /// 是否读取的事本地缓存的服务
+        /// Indicates whether the service list was loaded from the local cache.
         /// </summary>
         public bool IsLoadFromLocal
         {
@@ -131,7 +131,7 @@ namespace AgileConfig.Client.RegisterCenter
             int failCount = 0;
             var random = new RandomServers(_configClient.Options.Nodes);
             while (!random.IsComplete)
-            {   //随机一个节点尝试移除
+            {   // Try removing one random node at a time.
                 var host = random.Next();
                 var getUrl = host + (host.EndsWith("/") ? "" : "/") + $"api/registercenter/services";
                 try
@@ -175,7 +175,7 @@ namespace AgileConfig.Client.RegisterCenter
         }
 
         /// <summary>
-        /// 从本地缓存文件加载服务信息
+        /// Load service information from the local cache file.
         /// </summary>
         private void LoadServicesFromLocal()
         {
@@ -195,7 +195,7 @@ namespace AgileConfig.Client.RegisterCenter
         }
 
         /// <summary>
-        /// 保证cache文件夹存在
+        /// Ensure the cache directory exists.
         /// </summary>
         private void EnsureCacheDir()
         {
@@ -227,7 +227,7 @@ namespace AgileConfig.Client.RegisterCenter
         }
 
         /// <summary>
-        /// 尝试从本地文件读取缓存的服务信息
+        /// Try to read cached service information from a local file.
         /// </summary>
         /// <returns></returns>
         private string ReadServiceInfosContentFromLocal()

--- a/AgileConfig.Client/RegisterCenter/Heartbeats/HttpChannel.cs
+++ b/AgileConfig.Client/RegisterCenter/Heartbeats/HttpChannel.cs
@@ -28,7 +28,7 @@ namespace AgileConfig.Client.RegisterCenter.Heartbeats
             var json = JsonSerializer.Serialize(param);
             var data = Encoding.UTF8.GetBytes(json);
             while (!random.IsComplete)
-            {   //随机一个节点尝试移除
+            {   // Try removing one random node at a time.
                 var host = random.Next();
                 var postUrl = host + (host.EndsWith("/") ? "" : "/") + $"api/registercenter/heartbeat";
                 try
@@ -40,7 +40,7 @@ namespace AgileConfig.Client.RegisterCenter.Heartbeats
                         _logger.LogTrace($"HttpChannel send a heartbeat to {postUrl} success .");
 
                         var content = await HttpUtil.GetResponseContentAsync(resp);
-                        MessageCenter.Receive(content); //往外发送消息
+                        MessageCenter.Receive(content); // Forward the server response.
                     }
                     else
                     {

--- a/AgileConfig.Client/RegisterCenter/RegisterHostedService.cs
+++ b/AgileConfig.Client/RegisterCenter/RegisterHostedService.cs
@@ -27,7 +27,7 @@ namespace AgileConfig.Client.RegisterCenter
             logger.LogInformation("try to register serviceinfo to server .");
 
             await _registerService.RegisterAsync();
-            //客户端心跳
+            // Start the client heartbeat.
             _heartbeatService.Start(
                 () =>
                 {

--- a/AgileConfig.Client/RegisterCenter/RegisterService.cs
+++ b/AgileConfig.Client/RegisterCenter/RegisterService.cs
@@ -49,7 +49,7 @@ namespace AgileConfig.Client.RegisterCenter
             }
         }
 
-        //是否注册成功
+        // Indicates whether the registration succeeded.
         public bool Registered { get; private set; }
 
 
@@ -90,7 +90,7 @@ namespace AgileConfig.Client.RegisterCenter
             var data = Encoding.UTF8.GetBytes(json);
             var random = new RandomServers(_options.Nodes);
             while (!random.IsComplete)
-            {   //随机一个节点尝试移除
+            {   // Attempt removal on each node in random order.
                 var host = random.Next();
                 var postUrl = host + (host.EndsWith("/") ? "" : "/") + $"api/registercenter/{_uniqueId}";
                 try
@@ -136,7 +136,7 @@ namespace AgileConfig.Client.RegisterCenter
                     {
                         var random = new RandomServers(_options.Nodes);
                         while (!random.IsComplete)
-                        {   //随机一个节点尝试注册
+                        {   // Attempt registration on each node in random order.
                             var host = random.Next();
                             var postUrl = host + (host.EndsWith("/") ? "" : "/") + $"api/registercenter";
                             try

--- a/AgileConfig.Client/RegisterCenter/ServiceInfo.cs
+++ b/AgileConfig.Client/RegisterCenter/ServiceInfo.cs
@@ -26,12 +26,12 @@ namespace AgileConfig.Client.RegisterCenter
     public class ServiceRegisterInfo: ServiceInfo
     {
         /// <summary>
-        /// 健康检测地址
+        /// Health-check endpoint.
         /// </summary>
         public string CheckUrl { get; set; } = "";
 
         /// <summary>
-        /// 服务不健康的时候通知地址
+        /// Notification URL invoked when the service becomes unhealthy.
         /// </summary>
         public string AlarmUrl { get; set; } = "";
 

--- a/AgileConfig.ClientTest/appsettings.json
+++ b/AgileConfig.ClientTest/appsettings.json
@@ -4,27 +4,27 @@
     "secret": "testapp",
     //"nodes": "http://agileconfig-server.xbaby.xyz/",
     "nodes": "http://localhost:5000",
-    "name": "哈哈",
+    "name": "Sample client",
     "tag": "tag1",
     "env": "DEV",
     "httpTimeout": "10", //s
-    "cache": { // 指定缓存文件的目录
+    "cache": { // Directory used to store cached configuration files
       "directory": "c:/data"
     },
-    "reconnectInterval":  30, // websocket 重连间隔
-    "serviceRegister": { //服务注册信息
-      "serviceId": "test_app_service_02", //服务id，全局唯一，用来唯一标示某个服务, 非必填，如果不填，则自动生产一个guid，建议填写有意思的id
-      "serviceName": "test_client", //服务名，可以重复，某个服务多实例部署的时候这个serviceName就可以重复
-      "ip": "127.0.0.1", //服务的ip
-      "port": 5002, //服务的端口
-      "alarmUrl": "http://127.0.0.1:5100/home/servicedown", //告警地址，当服务不健康或者被移除的时候会往这个url post 数据，以便提醒
+    "reconnectInterval":  30, // WebSocket reconnection interval
+    "serviceRegister": { // Service registration settings
+      "serviceId": "test_app_service_02", // Globally unique identifier for the service. Optional; a GUID is generated when omitted. Pick something meaningful if possible
+      "serviceName": "test_client", // Service name. Can repeat when the service has multiple instances
+      "ip": "127.0.0.1", // Service IP address
+      "port": 5002, // Service port
+      "alarmUrl": "http://127.0.0.1:5100/home/servicedown", // Alert endpoint invoked when the service becomes unhealthy or is removed
       "metaData": [
         "this is a test client"
       ],
       "heartbeat": {
         "interval": 5
       },
-      "reregisterInterval": 30 // 服务注册信息重新注册的间隔
+      "reregisterInterval": 30 // Interval for re-registering service information
     }
   }
 }

--- a/AgileConfigConsoleSample/Program.cs
+++ b/AgileConfigConsoleSample/Program.cs
@@ -10,12 +10,14 @@ namespace AgileConfigConsoleSample
         {
             Console.WriteLine("Hello World!");
 
-            //控制台、类库项目，不一定有appsettngs.json文件，所以使用ConfigClient的有参构造函数手动传入appid等参数
-            //如果控制台项目同样建立了appsettings.json文件，那么同样可以跟mvc项目一样使用无参构造函数让Client自动读取appid等配置
+            // Console or class-library projects may not have an appsettings.json file,
+            // so use the constructor overload to supply appId and other settings manually.
+            // If the console app does include appsettings.json you can use the parameterless
+            // constructor, just like an MVC project, to load the settings automatically.
             var appId = "test_app";
             var secret = "test_app";
             var nodes = "http://agileconfig-server.xbaby.xyz/";
-            //使用有参构造函数，手动传入appid等信息
+            // Provide appId and related settings explicitly via the constructor.
             var client = new ConfigClient(appId, secret, nodes, "DEV");
             Task.Run(async () =>
             {
@@ -30,7 +32,7 @@ namespace AgileConfigConsoleSample
                 }
             });
 
-            client.ConnectAsync();//如果不是mvc项目，不使用AddAgileConfig方法的话，需要手动调用ConnectAsync方法来跟服务器建立连接
+            client.ConnectAsync();// Non-MVC projects that do not call AddAgileConfig need to invoke ConnectAsync manually.
 
             Console.WriteLine("Test started .");
             Console.Read();

--- a/AgileConfigDiscoveryServiceSample/Views/Home/Index.cshtml
+++ b/AgileConfigDiscoveryServiceSample/Views/Home/Index.cshtml
@@ -6,11 +6,11 @@
     <h1 class="display-4">service list</h1>
     <table class="table">
         <tr>
-            <th>服务id</th>
-            <th>服务名</th>
+            <th>Service ID</th>
+            <th>Service Name</th>
             <th>Ip</th>
-            <th>端口</th>
-            <th>状态</th>
+            <th>Port</th>
+            <th>Status</th>
         </tr>
            @{
         foreach(dynamic service in ViewBag.services)

--- a/AgileConfigDiscoveryServiceSample/appsettings.json
+++ b/AgileConfigDiscoveryServiceSample/appsettings.json
@@ -12,12 +12,12 @@
     "secret": "test_app",
     "nodes": "http://agileconfig-server.xbaby.xyz",
     "name": "discoveryServiceSample",
-    "serviceRegister": { //
-      "serviceId": "123456", //服务id，全局唯一，用来唯一标示某个服务
-      "serviceName": "discoveryServiceSample", //服务名，可以重复，某个服务多实例部署的时候这个serviceName就可以重复
-      "ip": "127.0.0.1", //服务的ip 可选
-      "port": 5005, //服务的端口 可选
-      "metaData": [ //携带服务的其他元数据 可选
+    "serviceRegister": { // Service registration information
+      "serviceId": "123456", // Globally unique service identifier
+      "serviceName": "discoveryServiceSample", // Service name. Can repeat when multiple instances are deployed
+      "ip": "127.0.0.1", // Service IP address (optional)
+      "port": 5005, // Service port (optional)
+      "metaData": [ // Additional service metadata (optional)
         "v1"
       ]
     }

--- a/AgileConfigMVCSample/Controllers/HomeController.cs
+++ b/AgileConfigMVCSample/Controllers/HomeController.cs
@@ -52,7 +52,7 @@ namespace AgileConfigMVCSample.Controllers
         }
 
         /// <summary>
-        /// 使用IConfiguration读取配置
+        /// Read configuration values via <see cref="IConfiguration"/>.
         /// </summary>
         /// <returns></returns>
         public IActionResult ByIConfiguration()
@@ -67,7 +67,7 @@ namespace AgileConfigMVCSample.Controllers
         }
 
         /// <summary>
-        /// 直接使用ConfigClient的实例读取配置
+        /// Read configuration values directly from <see cref="IConfigClient"/>.
         /// </summary>
         /// <returns></returns>
         public IActionResult ByInstance()
@@ -82,7 +82,7 @@ namespace AgileConfigMVCSample.Controllers
         }
 
         /// <summary>
-        /// 使用Options模式读取配置
+        /// Read configuration values via the Options pattern.
         /// </summary>
         /// <returns></returns>
         public IActionResult ByOptions()

--- a/AgileConfigMVCSample/Program.cs
+++ b/AgileConfigMVCSample/Program.cs
@@ -18,11 +18,11 @@ namespace AgileConfigMVCSample
             Host.CreateDefaultBuilder(args)
             .ConfigureAppConfiguration((context, config) =>
             {
-                //new一个client实例
-                //使用无参构造函数会自动读取本地appsettings.json文件的AgileConfig节点的配置
+                // Create a client instance.
+                // The parameterless constructor automatically reads the AgileConfig section from appsettings.json.
                 var configClient = new ConfigClient();
                
-                //注册配置项reloaded事件
+                // Register for configuration reload events.
                 configClient.ReLoaded += (arg) =>
                 {
                     foreach (var item in arg.NewConfigs)
@@ -31,7 +31,7 @@ namespace AgileConfigMVCSample
                     }
                 };
 
-                //使用AddAgileConfig配置一个新的IConfigurationSource
+                // Add an AgileConfig-backed IConfigurationSource.
                 config.AddAgileConfig(configClient);
             })
                 .ConfigureWebHostDefaults(webBuilder =>

--- a/AgileConfigMVCSample/appsettings.json
+++ b/AgileConfigMVCSample/appsettings.json
@@ -19,12 +19,12 @@
     "cache": {
       "directory": "agile/config"
     },
-    "serviceRegister": { //服务注册信息，如果不配置该节点，则不会启动任何跟服务注册相关的服务 可选
-      "serviceId": "test_mvc_app_01", //服务id，全局唯一，用来唯一标示某个服务
-      "serviceName": "test_mvc_app", //服务名，可以重复，某个服务多实例部署的时候这个serviceName就可以重复
-      "ip": "127.0.0.1", //服务的ip
-      "port": 5100, //服务的端口
-      "metaData": [ //携带服务的其他元数据 可选
+    "serviceRegister": { // Service registration information. Omit to disable registration.
+      "serviceId": "test_mvc_app_01", // Globally unique service identifier
+      "serviceName": "test_mvc_app", // Service name. Can repeat when multiple instances are deployed
+      "ip": "127.0.0.1", // Service IP address
+      "port": 5100, // Service port
+      "metaData": [ // Additional service metadata (optional)
         "my name is MJ",
         "ECS=001",
         "v1"

--- a/AgileConfigMVCSampleNET5/appsettings.json
+++ b/AgileConfigMVCSampleNET5/appsettings.json
@@ -15,19 +15,19 @@
     "nodes": "http://localhost:5000",
     "name": "client123",
     "tag": "tag123",
-    "serviceRegister": { //����ע����Ϣ����������øýڵ㣬�򲻻�����κθ�����ע����صķ��� ��ѡ
-      "serviceId": "test_mvc5_01", //����id��ȫ��Ψһ������Ψһ��ʾĳ������
-      "serviceName": "test_mvc5", //�������������ظ���ĳ�������ʵ�������ʱ�����serviceName�Ϳ����ظ�
-      "ip": "127.0.0.1", //�����ip ��ѡ
-      "port": 5002, //����Ķ˿� ��ѡ
-      "metaData": [ //Я�����������Ԫ���� ��ѡ
+    "serviceRegister": { // Service registration information. Omit to disable registration.
+      "serviceId": "test_mvc5_01", // Globally unique service identifier
+      "serviceName": "test_mvc5", // Service name. Can repeat when multiple instances are deployed
+      "ip": "127.0.0.1", // Service IP address (optional)
+      "port": 5002, // Service port (optional)
+      "metaData": [ // Additional metadata for the service (optional)
         "v1"
-      ], 
-      //"alarmUrl": "http://127.0.0.1:5100/servicedown", //�澯��ַ�������񲻽������߱��Ƴ���ʱ��������url post ���ݣ��Ա����� ��ѡ
-      //"heartbeat": { 
-      //  "mode": "server", //ָ��������ģʽ��server/client ��server��������������⣬client����ͻ��������ϱ�������Ĭ��clientģʽ ��ѡ
-      //  "url": "http://127.0.0.1:5002/WeatherForecast", //����ģʽΪ server ��ʱ����Ҫ��д��������ַ�������httpstatus=200���ж�����������Ϊʧ�� ��ѡ
-      //  "interval": 30 ��ѡ
+      ]
+      //"alarmUrl": "http://127.0.0.1:5100/servicedown", // Alert endpoint invoked when the service becomes unhealthy or is removed (optional)
+      //"heartbeat": {
+      //  "mode": "server", // Heartbeat mode: server-side probing (`server`) or client-side reporting (`client`, default)
+      //  "url": "http://127.0.0.1:5002/WeatherForecast", // Health-check endpoint when using server-side heartbeat. HTTP 2xx is considered healthy; other statuses indicate failure
+      //  "interval": 30 // Heartbeat interval in seconds (optional)
       //}
     }
   }

--- a/AgileConfigMVCSampleNET6/appsettings.json
+++ b/AgileConfigMVCSampleNET6/appsettings.json
@@ -13,19 +13,19 @@
     "nodes": "http://agileconfig-server.xbaby.xyz/",
     "name": "client123",
     "tag": "tag123",
-    "serviceRegister": { //服务注册信息，如果不配置该节点，则不会启动任何跟服务注册相关的服务 可选
-      "serviceId": "net6", //服务id，全局唯一，用来唯一标示某个服务
-      "serviceName": "net6MVC服务测试", //服务名，可以重复，某个服务多实例部署的时候这个serviceName就可以重复
-      "ip": "127.0.0.1", //服务的ip 可选
-      "port": 5005, //服务的端口 可选
-      "metaData": [ //携带服务的其他元数据 可选
+    "serviceRegister": { // Service registration information. Omit to disable registration.
+      "serviceId": "net6", // Globally unique service identifier
+      "serviceName": "net6 MVC sample", // Service name. Can repeat when running multiple instances of the same service
+      "ip": "127.0.0.1", // Service IP address (optional)
+      "port": 5005, // Service port (optional)
+      "metaData": [ // Additional metadata for the service (optional)
         "v1"
       ]
-      //"alarmUrl": "http://127.0.0.1:5100/servicedown", //告警地址，当服务不健康或者被移除的时候会往这个url post 数据，以便提醒 可选
+      //"alarmUrl": "http://127.0.0.1:5100/servicedown", // Alert endpoint invoked when the service becomes unhealthy or is removed (optional)
       //"heartbeat": { 
-      //  "mode": "server", //指定心跳的模式，server/client 。server代表服务端主动检测，client代表客户端主动上报。不填默认client模式 可选
-      //  "url": "http://127.0.0.1:5002/WeatherForecast", //心跳模式为 server 的时候需要填写健康检测地址，如果是httpstatus=200则判定存活，其它都视为失败 可选
-      //  "interval": 30 可选
+      //  "mode": "server", // Heartbeat mode: server-side probing (`server`) or client-side reporting (`client`, default)
+      //  "url": "http://127.0.0.1:5002/WeatherForecast", // Health-check endpoint when using server-side heartbeat. HTTP 2xx is considered healthy; other statuses indicate failure
+      //  "interval": 30 // Heartbeat interval in seconds (optional)
       //}
     }
   }

--- a/AgileConfigWPFSample/App.xaml.cs
+++ b/AgileConfigWPFSample/App.xaml.cs
@@ -17,7 +17,8 @@ namespace AgileConfigWPFSample
         public static ConfigClient ConfigClient { get; private set; }
         private void Application_Startup(object sender, StartupEventArgs e)
         {
-            //跟控制台项目一样，appid等信息取决于你如何获取。你可以写死，可以从配置文件读取，可以从别的web service读取。
+            // Similar to a console project, decide how to obtain appId and related settings:
+            // hard-code them, read from configuration, or fetch from another service.
             var appId = "test_app";
             var secret = "test_app";
             var nodes = "http://agileconfig-server.xbaby.xyz/";

--- a/OnFrameworkTest/Properties/AssemblyInfo.cs
+++ b/OnFrameworkTest/Properties/AssemblyInfo.cs
@@ -2,9 +2,8 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// 有关程序集的一般信息由以下
-// 控制。更改这些特性值可修改
-// 与程序集关联的信息。
+// General assembly information is controlled through the following
+// set of attributes. Change these values to modify the assembly metadata.
 [assembly: AssemblyTitle("OnFrameworkTest")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
@@ -14,23 +13,22 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// 将 ComVisible 设置为 false 会使此程序集中的类型
-//对 COM 组件不可见。如果需要从 COM 访问此程序集中的类型
-//请将此类型的 ComVisible 特性设置为 true。
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components. To expose a type to COM, set the ComVisible attribute to true.
 [assembly: ComVisible(false)]
 
-// 如果此项目向 COM 公开，则下列 GUID 用于类型库的 ID
+// The following GUID is for the ID of the typelib if this project is exposed to COM.
 [assembly: Guid("278206be-f59f-4d3f-a5c5-6a11b52e3a3b")]
 
-// 程序集的版本信息由下列四个值组成: 
+// Version information for an assembly consists of the following four values:
 //
-//      主版本
-//      次版本
-//      生成号
-//      修订号
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
 //
-//可以指定所有这些值，也可以使用“生成号”和“修订号”的默认值
-//通过使用 "*"，如下所示:
+// You can specify all the values or default the Build and Revision Numbers
+// by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]

--- a/README.md
+++ b/README.md
@@ -1,20 +1,25 @@
 # AgileConfig_Client
-AgileConfig 的客户端，.net core standard2.0实现 。     
+
+AgileConfig client implemented with .NET Standard 2.0.
 
 ![Nuget](https://github.com/kklldog/AgileConfig_Client/actions/workflows/publish2nuget.yml/badge.svg?branch=publish)
 ![Nuget](https://img.shields.io/nuget/v/agileconfig.client)
 ![Nuget](https://img.shields.io/nuget/dt/agileconfig.client?label=download)
-## 使用客户端
-### 安装客户端
+
+## Using the client
+
+### Install the client
+
 ```
 Install-Package AgileConfig.Client
 ```
 
-☢️☢️☢️如果你的程序是Framework的程序请使用[AgileConfig.Client4FR](https://github.com/kklldog/AgileConfig.Client4FR)这个专门为Framework打造的client。使用当前版本有可能死锁造成cpu100% 的风险。☢️☢️☢️
+☢️☢️☢️ If your application targets .NET Framework please use [AgileConfig.Client4FR](https://github.com/kklldog/AgileConfig.Client4FR), which is built specifically for Framework apps. Using the current package may lead to deadlocks and 100% CPU usage. ☢️☢️☢️
 
-### 初始化客户端
-以asp.net core mvc项目为例：   
-在appsettings.json文件内配置agileconfig的连接信息。
+### Initialize the client
+
+Using an ASP.NET Core MVC project as an example, configure the AgileConfig connection info in `appsettings.json`.
+
 ```
 {
   "Logging": {
@@ -30,7 +35,7 @@ Install-Package AgileConfig.Client
   "AgileConfig": {
     "appId": "app",
     "secret": "xxx",
-    "nodes": "http://localhost:5000,http://localhost:5001"//多个节点使用逗号分隔,
+    "nodes": "http://localhost:5000,http://localhost:5001",//Multiple nodes are separated by commas
     "name": "client1",
     "tag": "tag1",
     "env": "DEV",
@@ -40,26 +45,28 @@ Install-Package AgileConfig.Client
     }
   }
 }
-
 ```
-#### 配置项说明
 
-|配置项名称|数据类型|配置项说明|是否必填|备注|
+#### Configuration options
+
+|Name|Type|Description|Required|Remarks|
 |--|--|--|--|--|
-|appid|string|应用ID|是|对应后台管理中应用的`应用ID`|
-|secret|string|应用密钥|是|对应后台管理中应用的`密钥`|
-|nodes|string|应用配置节点|是|存在多个节点则使用逗号`,`分隔|
-|name|string|连接客户端的自定义名称|否|方便在agile配置中心后台对当前客户端进行查阅与管理|
-|tag|string|连接客户端自定义标签|否|方便在agile配置中心后台对当前客户端进行查阅与管理|
-|env|string|配置中心的环境|否|通过此配置决定拉取哪个环境的配置信息；如果不配置，服务端会默认返回第一个环境的配置|
-|cache|string|客户端的配置缓存设置|否|通过此配置可对拉取到本地的配置项文件进行相关设置|
-|cache:enabled|bool|是否在本地缓存上一次拉取的配置|否|默认 true|
-|cache:directory|string|客户端的配置缓存文件存储地址配置|否|如设置了此目录则将拉取到的配置项cache文件存储到该目录，否则直接存储到站点根目录|
-|cache:config_encrypt|bool|客户端缓存文件加密设置|否|如果设置为`true`则对缓存的文件内容进行加密|
-|httpTimeout|int|http请求超时时间|否|配置 client 发送 http 请求的时候的超时时间，默认100s|
+|appid|string|Application ID|Yes|Matches the **Application ID** configured in the server console|
+|secret|string|Application secret|Yes|Matches the **Secret** configured in the server console|
+|nodes|string|Server node endpoints|Yes|Separate multiple nodes with commas (`,`)|
+|name|string|Custom client name|No|Helps identify the client in the AgileConfig admin console|
+|tag|string|Custom client tag|No|Helps group or search for the client in the admin console|
+|env|string|Target environment|No|Determines which environment configuration the client pulls. If omitted, the server returns the first environment by default|
+|cache|string|Client cache configuration|No|Allows additional settings for persisting configs locally|
+|cache:enabled|bool|Cache the last pulled configuration locally|No|Defaults to `true`|
+|cache:directory|string|Directory where cached configuration files are stored|No|If omitted, cache files are stored in the application root|
+|cache:config_encrypt|bool|Encrypt cached configuration files|No|When `true` the cache file contents are encrypted|
+|httpTimeout|int|HTTP request timeout|No|Timeout in seconds for HTTP requests; defaults to 100s|
 
 ## UseAgileConfig
-在 program 类上使用 UseAgileConfig 扩展方法，该方法会配置一个 AgileConfig 的配置源。
+
+Call the `UseAgileConfig` extension on `Program` to add the AgileConfig configuration source.
+
 ```
  public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
@@ -69,8 +76,11 @@ Install-Package AgileConfig.Client
                     webBuilder.UseStartup<Startup>();
                 });
 ```
-## 读取配置
-AgileConfig支持asp.net core 标准的IConfiguration，跟IOptions模式读取配置。还支持直接通过AgileConfigClient实例直接读取：
+
+## Read configuration
+
+AgileConfig supports the standard ASP.NET Core `IConfiguration` and `IOptions` patterns. You can also read values directly from an `AgileConfigClient` instance.
+
 ```
 public class HomeController : Controller
     {
@@ -93,7 +103,7 @@ public class HomeController : Controller
         }
 
         /// <summary>
-        /// 使用IConfiguration读取配置
+        /// Read configuration values via IConfiguration
         /// </summary>
         /// <returns></returns>
         public IActionResult ByIConfiguration()
@@ -108,7 +118,7 @@ public class HomeController : Controller
         }
 
         /// <summary>
-        /// 直接使用ConfigClient的实例读取配置
+        /// Read configuration values directly from ConfigClient
         /// </summary>
         /// <returns></returns>
         public IActionResult ByInstance()
@@ -123,7 +133,7 @@ public class HomeController : Controller
         }
 
         /// <summary>
-        /// 使用Options模式读取配置
+        /// Read configuration values via the Options pattern
         /// </summary>
         /// <returns></returns>
         public IActionResult ByOptions()
@@ -135,8 +145,11 @@ public class HomeController : Controller
         }
     }
 ```
-## 使用服务注册&发现
-在 appsettings.json 的 AgileConfig 节点添加 serviceRegister 节点：
+
+## Service registration & discovery
+
+Add the `serviceRegister` section under `AgileConfig` in `appsettings.json`:
+
 ```
  "AgileConfig": {
     "appId": "test_app",
@@ -145,48 +158,48 @@ public class HomeController : Controller
     "name": "client123",
     "tag": "tag123",
 
-    "serviceRegister": { //服务注册信息，如果不配置该节点，则不会启动任何跟服务注册相关的服务 可选
-      "serviceId": "net6", //服务id，全局唯一，用来唯一标示某个服务 ，client 1.6.12 开始不再必填。如果不填，则自动生产一个 guid
-      "serviceName": "net6MVC服务测试", //服务名，可以重复，某个服务多实例部署的时候这个serviceName就可以重复
-      "ip": "127.0.0.1", //服务的ip 可选
-      "port": 5005, //服务的端口 可选
+    "serviceRegister": { //Service registration information; omit this section to disable registration (optional)
+      "serviceId": "net6", //Service ID. Must be globally unique. Optional since client 1.6.12, otherwise a GUID is generated
+      "serviceName": "net6 MVC sample", //Service name. Can repeat when you deploy multiple instances of the same service
+      "ip": "127.0.0.1", //Service IP (optional)
+      "port": 5005 //Service port (optional)
+    }
   }
 ```
-其中 appId , secret 等配置同原来配置中心的使用方式没有任何改变。   
-`serviceRegister` 节点描述的是服务注册信息（如果删除这个节点那么服务注册功能就不会启动）：   
-- serviceId  
-服务id，全局唯一，用来唯一标示某个服务，client 1.6.12 开始不再必填。如果不填，则自动生产一个 guid
-- serviceName  
-服务名，可以重复，某个服务多实例部署的时候这个serviceName就可以重复  
-- ip  
-服务的ip 可选
-- port   
-服务的端口 可选
-- metaData  
-一个字符串数组，可以携带一些服务的相关信息，如版本等 可选
-- alarmUrl  
-告警地址 可选。   
-如果某个服务出现异常情况，如一段时间内没有心跳，那么服务端会往这个地址 POST 一个请求并且携带服务相关信息，用户可以自己去实现提醒功能，比如发短信，发邮件等：
+
+The `appId`, `secret`, and other standard configuration fields work exactly the same as with the configuration center alone.
+
+`serviceRegister` describes the service registration payload. Removing this node disables registration entirely:
+
+- **serviceId** – Globally unique service identifier. Optional starting with client 1.6.12; when omitted the client generates a GUID.
+- **serviceName** – Friendly service name. Can repeat when multiple instances of the same service are deployed.
+- **ip** – Service IP address (optional).
+- **port** – Service port (optional).
+- **metaData** – Optional string array for metadata such as version information.
+- **alarmUrl** – Optional alert callback endpoint. If the service becomes unhealthy (for example, no heartbeat is detected for a period of time) the server POSTs a notification to this address with service details. You can implement the endpoint to send SMS, emails, and so on:
+
 ```
 {
     "serviceId":"0001",
     "serviceName":"xxxx",
     "time":"2022-01-01T12:00:000",
     "status":"Unhealty",
-    "message": "服务不健康"
+    "message": "Service is unhealthy"
 }
 ```
-- heartbeat:mode  
-指定心跳的模式，server/client 。server代表服务端主动检测，client代表客户端主动上报。不填默认client模式 可选
-- heartbeat:interval  
-心跳的间隔，默认时间30s 可选
-- heartbeat:url  
-心跳模式为 server 的时候需要填写健康检测地址，如果是httpstatus为200段则判定存活，其它都视为失败 可选   
-### 服务的注册
-当配置好客户端后，启动对应的应用程序，服务信息会自动注册到服务端并且开始心跳。如果服务正确注册到服务端，控制台的服务管理界面可以查看：
-![](https://static.xbaby.xyz/serviceregister.png)
-### 服务发现
-现在服务已经注册上去了，那么怎么才能拿到注册中心所有的服务呢？同样非常简单，在程序内只要注入`IDiscoveryService `接口就可以通过它拿到所有的注册的服务。
+
+- **heartbeat:mode** – Heartbeat mode: `server` for server-side probing, `client` for client-side reporting (default).
+- **heartbeat:interval** – Heartbeat interval in seconds (default 30s).
+- **heartbeat:url** – Health-check endpoint when `mode` is `server`. HTTP 2xx indicates healthy, all other statuses are treated as failure.
+
+### Service registration
+
+After configuring the client and starting the application, the service information is automatically registered and heartbeats begin. You can verify the registration from the service management page in the console.
+
+### Service discovery
+
+Inject `IDiscoveryService` to access all registered services from your application.
+
 ```
 public interface IDiscoveryService
     {
@@ -197,7 +210,9 @@ public interface IDiscoveryService
         Task RefreshAsync();
     }
 ```
-除了接口内置的方法，还有几个扩展方法方便用户使用，比如随机一个服务：
+
+Besides the built-in members, a few extension methods are provided to simplify common scenarios such as selecting a random service instance:
+
 ```
     public static class DiscoveryServiceExtension
     {
@@ -217,6 +232,9 @@ public interface IDiscoveryService
         }
     }
 ```
-## 联系我
-有什么问题可以mail我：minj.zhou@gmail.com
-也可以加qq群：1022985150
+
+## Contact
+
+Email: minj.zhou@gmail.com
+
+QQ group: 1022985150


### PR DESCRIPTION
## Summary
- translate the README to English and clarify configuration instructions
- convert inline code comments and XML docs to English across the AgileConfig client library
- update sample application configuration files and views with English comments and labels

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ecba46f01c8329a74959583ac0c9e3