### PR TITLE
Implement lazy DI logger in AgileConfig.Client for global logging

### DIFF
--- a/AgileConfig.Client/ClientShutdownHostService.cs
+++ b/AgileConfig.Client/ClientShutdownHostService.cs
@@ -13,6 +13,8 @@ namespace AgileConfig.Client
 
         public ClientShutdownHostService(IConfigClient configClient)
         {
+            // Resolve IConfigClient when hosted service starts so logger rebinding is not
+            // dependent on application code explicitly injecting IConfigClient.
             _configClient = configClient;
         }
 

--- a/AgileConfig.Client/ClientShutdownHostService.cs
+++ b/AgileConfig.Client/ClientShutdownHostService.cs
@@ -9,6 +9,13 @@ namespace AgileConfig.Client
 {
     class ClientShutdownHostService : IHostedService
     {
+        private readonly IConfigClient _configClient;
+
+        public ClientShutdownHostService(IConfigClient configClient)
+        {
+            _configClient = configClient;
+        }
+
         public Task StartAsync(CancellationToken cancellationToken)
         {
             return Task.CompletedTask;
@@ -19,7 +26,7 @@ namespace AgileConfig.Client
             try
             {
                 // close websocket
-                await ConfigClient.Instance?.DisconnectAsync();
+                await _configClient?.DisconnectAsync();
             }
             catch
             {

--- a/AgileConfig.Client/ConfigClientOptions.cs
+++ b/AgileConfig.Client/ConfigClientOptions.cs
@@ -261,26 +261,31 @@ namespace AgileConfig.Client
             }
         }
 
+        private static readonly object _consoleLoggerLock = new object();
         private static ILogger _consoleLogger;
+        // Keep the factory alive so the logger it produced remains functional.
+        private static ILoggerFactory _consoleLoggerFactory;
         public static ILogger DefaultConsoleLogger
         {
             get
             {
-                if (_consoleLogger != null)
+                if (_consoleLogger == null)
                 {
-                    return _consoleLogger;
+                    lock (_consoleLoggerLock)
+                    {
+                        if (_consoleLogger == null)
+                        {
+                            _consoleLoggerFactory = LoggerFactory.Create(lb =>
+                            {
+                                lb.SetMinimumLevel(LogLevel.Trace);
+                                lb.AddConsole();
+                            });
+                            _consoleLogger = _consoleLoggerFactory.CreateLogger<ConfigClient>();
+                        }
+                    }
                 }
 
-                using (var loggerFactory = LoggerFactory.Create(lb =>
-                {
-                    lb.SetMinimumLevel(LogLevel.Trace);
-                    lb.AddConsole();
-                }))
-                {
-                    var logger = loggerFactory.CreateLogger<ConfigClient>();
-                    _consoleLogger = logger;
-                    return _consoleLogger;
-                }
+                return _consoleLogger;
             }
         }
     }

--- a/AgileConfig.Client/Extensions/ServiceCollectionExtension.cs
+++ b/AgileConfig.Client/Extensions/ServiceCollectionExtension.cs
@@ -8,8 +8,20 @@ namespace Microsoft.Extensions.DependencyInjection
     {
         public static void AddAgileConfig(this IServiceCollection services)
         {
-            ConfigClient.Instance.Logger = GetLogger(services);
-            services.AddSingleton(sp => ConfigClient.Instance);
+            // Register IConfigClient as a lazy singleton so that the logger is resolved from
+            // the fully-built DI container (which already includes every logging provider the
+            // host has registered, e.g. NLog / Serilog) instead of from a temporary container
+            // built at service-registration time.
+            services.AddSingleton<IConfigClient>(sp =>
+            {
+                var instance = ConfigClient.Instance;
+                var loggerFactory = sp.GetService<ILoggerFactory>();
+                if (loggerFactory != null)
+                {
+                    instance.Logger = loggerFactory.CreateLogger<ConfigClient>();
+                }
+                return instance;
+            });
             services.AddHostedService<ClientShutdownHostService>();
             if (ConfigClient.Instance.Options.RegisterInfo != null)
             {
@@ -22,12 +34,6 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton<IRegisterService, RegisterService>();
             services.AddSingleton<IDiscoveryService, DiscoveryService>();
             services.AddHostedService<RegisterHostedService>();
-        }
-
-        private static ILogger GetLogger(IServiceCollection services)
-        {
-            var logger = services.BuildServiceProvider().GetService<ILoggerFactory>().CreateLogger<ConfigClient>();
-            return logger;
         }
     }
 }


### PR DESCRIPTION
This pull request improves how logging is handled and how the `ConfigClient` is registered in the dependency injection (DI) container. The main focus is to ensure that the logger is correctly resolved from the final DI container, allowing it to use any logging providers (like NLog or Serilog) that the host application has registered. This change also addresses issues with logger lifetime and thread safety.

**Dependency Injection and Logging Improvements:**

* Changed registration of `IConfigClient` in `ServiceCollectionExtension.cs` to use a lazy singleton, ensuring the logger is resolved from the fully-built DI container and supports all registered logging providers.
* Removed the `GetLogger` helper method, which previously built a temporary service provider to resolve the logger, preventing premature or incorrect logger instantiation.

**Thread Safety and Logger Lifetime:**

* Updated the `DefaultConsoleLogger` in `ConfigClientOptions.cs` to be thread-safe and to keep the `ILoggerFactory` alive, ensuring the logger remains functional throughout the application's lifetime.